### PR TITLE
go126

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,4 +22,4 @@ jobs:
           check-latest: true
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.5
+          version: v2.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/joeig/dyndns-pdns
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20180315120708-ccb8e960c48f


### PR DESCRIPTION
- **Use Go 1.26**
- **Bump golangci-lint to v2.9.0**
